### PR TITLE
Add metadata to ncovtools

### DIFF
--- a/extra_data/config.yaml
+++ b/extra_data/config.yaml
@@ -25,7 +25,7 @@ consensus_pattern: "{data_root}/{sample}.consensus.fasta"
 # some plots can by annotated with external metadata. this
 # file contains the metadata in simple tab-delimited format
 # one column must be 'sample'
-#metadata: metadata.tsv
+metadata: ./run/*.tsv
 
 #
 # set this flag to true to include lineage assignments with pangolin in the output plots

--- a/extra_data/config.yaml
+++ b/extra_data/config.yaml
@@ -1,14 +1,14 @@
 # path to the top-level directory containing the analysis results
-data_root: ./run
+data_root: run
 
 # optionally the plots can have a "run name" prefix. If this is not defined the prefix will be "default"
 run_name: nml
 
 # path to the file containing the amplicon regions (not the primer sites, the actual amplicons)
-amplicon_bed: ./ncov-qc_resende.bed
+amplicon_bed: ncov-qc_resende.bed
 
 # path to the nCov reference genome
-reference_genome: ./nCoV-2019.reference.fasta
+reference_genome: nCoV-2019.reference.fasta
 
 # the naming convention for the bam files
 # this can use the variables {data_root} (as above) and {sample}
@@ -25,7 +25,7 @@ consensus_pattern: "{data_root}/{sample}.consensus.fasta"
 # some plots can by annotated with external metadata. this
 # file contains the metadata in simple tab-delimited format
 # one column must be 'sample'
-metadata: ./run/*.tsv
+metadata: metadata.tsv
 
 #
 # set this flag to true to include lineage assignments with pangolin in the output plots

--- a/modules/help.nf
+++ b/modules/help.nf
@@ -43,7 +43,8 @@ def printHelp() {
       --outCram               Output cram instead of bam files (Default: false)
 
       --ncov                  Path to ncov-tools config file (Default: baseDir/extra_data/config.yaml, disabled by setting to false)
-      --irida                 Path to Irida sample list csv file (Default: false)
+      --irida                 Path to Irida sample_list.tsv file to rename data and upload to Irida (Default: false)
+                              Sample_list.tsv should be formated as [sample, run, barcode, project_id, ct]
  
   Illumina workflow options:
     Mandatory:

--- a/modules/nml.nf
+++ b/modules/nml.nf
@@ -56,6 +56,7 @@ process runNcovTools {
     file(reference)
     file(amplicon)
     file(nanopolishresults)
+    file(metadata)
 
     output:
     file("*.pdf")
@@ -65,7 +66,7 @@ process runNcovTools {
     git clone https://github.com/jts/ncov-tools.git
     mv ${config} ${reference} ${amplicon} ./ncov-tools
     mkdir ./ncov-tools/run
-    mv *.* ./ncov-tools/run
+    mv *.sorted.bam *.consensus.fasta ${metadata} ./ncov-tools/run
     cd ncov-tools
     snakemake -s qc/Snakefile all_qc_sequencing --cores 8
     snakemake -s qc/Snakefile all_qc_analysis --cores 8

--- a/modules/nml.nf
+++ b/modules/nml.nf
@@ -65,8 +65,9 @@ process runNcovTools {
     """
     git clone https://github.com/jts/ncov-tools.git
     mv ${config} ${reference} ${amplicon} ./ncov-tools
+    mv ${metadata} ./ncov-tools/metadata.tsv
     mkdir ./ncov-tools/run
-    mv *.sorted.bam *.consensus.fasta ${metadata} ./ncov-tools/run
+    mv *.sorted.bam *.consensus.fasta ./ncov-tools/run
     cd ncov-tools
     snakemake -s qc/Snakefile all_qc_sequencing --cores 8
     snakemake -s qc/Snakefile all_qc_analysis --cores 8

--- a/modules/nml.nf
+++ b/modules/nml.nf
@@ -62,15 +62,31 @@ process runNcovTools {
     file("*.pdf")
 
     script:
-    """
-    git clone https://github.com/jts/ncov-tools.git
-    mv ${config} ${reference} ${amplicon} ./ncov-tools
-    mv ${metadata} ./ncov-tools/metadata.tsv
-    mkdir ./ncov-tools/run
-    mv *.sorted.bam *.consensus.fasta ./ncov-tools/run
-    cd ncov-tools
-    snakemake -s qc/Snakefile all_qc_sequencing --cores 8
-    snakemake -s qc/Snakefile all_qc_analysis --cores 8
-    mv ./plots/* ../
-    """
+    
+    if ( params.irida )
+    
+        """
+        git clone https://github.com/jts/ncov-tools.git
+        mv ${config} ${reference} ${amplicon} ./ncov-tools
+        mv ${metadata} ./ncov-tools/metadata.tsv
+        mkdir ./ncov-tools/run
+        mv *.sorted.bam *.consensus.fasta ./ncov-tools/run
+        cd ncov-tools
+        snakemake -s qc/Snakefile all_qc_sequencing --cores 8
+        snakemake -s qc/Snakefile all_qc_analysis --cores 8
+        mv ./plots/* ../
+        """
+    
+    else
+        """
+        git clone https://github.com/jts/ncov-tools.git
+        sed -i -e 's/^metadata/#metadata/' ${config} 
+        mv ${config} ${reference} ${amplicon} ./ncov-tools
+        mkdir ./ncov-tools/run
+        mv *.sorted.bam *.consensus.fasta ./ncov-tools/run
+        cd ncov-tools
+        snakemake -s qc/Snakefile all_qc_sequencing --cores 8
+        snakemake -s qc/Snakefile all_qc_analysis --cores 8
+        mv ./plots/* ../
+        """
 }

--- a/workflows/articNcovNanopore.nf
+++ b/workflows/articNcovNanopore.nf
@@ -95,7 +95,8 @@ workflow sequenceAnalysisNanopolish {
                       articDownloadScheme.out.ncov_amplicon, 
                       articMinIONNanopolish.out[0].toList()
                                                   .flatten()
-                                                  .toList())
+                                                  .toList(),
+                      ch_irida)
       }
 
     emit:

--- a/workflows/articNcovNanopore.nf
+++ b/workflows/articNcovNanopore.nf
@@ -53,6 +53,9 @@ workflow sequenceAnalysisNanopolish {
        generateIridaReport(articGuppyPlex.out.fastq.toList(), ch_irida)
       }
       else {
+       Channel.fromPath("${params.irida}")
+              .set{ ch_irida }
+
        articMinIONNanopolish(articGuppyPlex.out.fastq
                                           .combine(articDownloadScheme.out.scheme)
                                           .combine(ch_fast5Pass)


### PR DESCRIPTION
Changes:

- csv parsing for sample info changed to tsv
- updates to help statements to reflect changes
- More specific file transfer to `./ncovtools/run` directory for ncovtools process

Still needs to be addressed:

- ~~what to do with ncovtools when `--irida` is not used as making the config won't find the metadata if `--irida` is not specified~~ --> Done

- May need to find a better way to use/create irida channel for when its not used and ncov tools is