### PR TITLE
Add conda dir to nextflow.config

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -24,6 +24,7 @@ if ( params.illumina ){
     includeConfig 'conf/illumina.config'
 }
 
+conda.cacheDir = '/Drives/P/conda_envs/connor-lab'
 
 profiles {
   conda {


### PR DESCRIPTION
Adding the nml conda dir to nextflow.config for the moment as remembering to re-specify it each time is annoying (and the pipeline will fail due to file paths being too long otherwise)