### PR TITLE
Read size and read number filters

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -5,7 +5,7 @@ nextflow.preview.dsl = 2
 
 // include modules
 include printHelp from './modules/help.nf'
-include fewReadsIN from './modules/nml.nf'
+include accountNoReadsInput from './modules/nml.nf'
 
 // import subworkflows
 include {articNcovNanopore} from './workflows/articNcovNanopore.nf' 
@@ -114,7 +114,7 @@ workflow {
                             count > params.minReadsPerBarcode
                    }.set{ ch_fastqDirs }
             
-            fewReadsIN(ch_badfastqDirs.collect())
+            accountNoReadsInput(ch_badfastqDirs.collect())
 
        } else if ( nanoporeNoBarcode ){
             // No, no barcodes

--- a/main.nf
+++ b/main.nf
@@ -5,6 +5,7 @@ nextflow.preview.dsl = 2
 
 // include modules
 include printHelp from './modules/help.nf'
+include fewReadsIN from './modules/nml.nf'
 
 // import subworkflows
 include {articNcovNanopore} from './workflows/articNcovNanopore.nf' 
@@ -99,8 +100,22 @@ workflow {
                                     count += x.countFastq()
                                 }
                             }
+                            count <= params.minReadsPerBarcode
+                   }.set{ ch_badfastqDirs }
+            Channel.fromPath( nanoporeBarcodeDirs )
+                   .filter( ~/.*barcode[0-9]{1,4}$/ )
+                   .filter{ d ->
+                            def count = 0
+                            for (x in d.listFiles()) {
+                                if (x.isFile()) {
+                                    count += x.countFastq()
+                                }
+                            }
                             count > params.minReadsPerBarcode
                    }.set{ ch_fastqDirs }
+            
+            fewReadsIN(ch_badfastqDirs.collect())
+
        } else if ( nanoporeNoBarcode ){
             // No, no barcodes
             Channel.fromPath( "${params.basecalled_fastq}", type: 'dir', maxDepth: 1 )

--- a/modules/nml.nf
+++ b/modules/nml.nf
@@ -19,6 +19,42 @@ process renameSamples {
     """
 }
 
+process fewReadsIN {
+
+    label 'smallmem'
+
+    publishDir "${params.outdir}/", pattern: "READ_NUMBER_FILTERED_OUT.txt", mode: "copy"
+
+    input:
+    path(fastq_dir)
+
+    output:
+    file('READ_NUMBER_FILTERED_OUT.txt')
+
+    script:
+    """
+    ls -d */ > READ_NUMBER_FILTERED_OUT.txt
+    """
+}
+
+process zeroReadsFiltered {
+
+    label 'smallmem'
+
+    publishDir "${params.outdir}/", pattern: "READ_LENGTH_FILTERED_OUT.txt", mode: "copy"
+
+    input:
+    path(fastq)
+
+    output:
+    file('READ_LENGTH_FILTERED_OUT.txt')
+
+    script:
+    """
+    ls *.fastq > READ_LENGTH_FILTERED_OUT.txt
+    """
+}
+
 process generateFastqIridaReport {
 
     publishDir "${params.outdir}", pattern: "irida_fastq", mode: "copy"

--- a/modules/nml.nf
+++ b/modules/nml.nf
@@ -19,39 +19,39 @@ process renameSamples {
     """
 }
 
-process fewReadsIN {
+process accountNoReadsInput {
 
     label 'smallmem'
 
-    publishDir "${params.outdir}/", pattern: "READ_NUMBER_FILTERED_OUT.txt", mode: "copy"
+    publishDir "${params.outdir}/", pattern: "samples_failing_no_input_reads.txt", mode: "copy"
 
     input:
     path(fastq_dir)
 
     output:
-    file('READ_NUMBER_FILTERED_OUT.txt')
+    file('samples_failing_no_input_reads.txt')
 
     script:
     """
-    ls -d */ > READ_NUMBER_FILTERED_OUT.txt
+    ls -d */ > samples_failing_no_input_reads.txt
     """
 }
 
-process zeroReadsFiltered {
+process accountReadFilterFailures {
 
     label 'smallmem'
 
-    publishDir "${params.outdir}/", pattern: "READ_LENGTH_FILTERED_OUT.txt", mode: "copy"
+    publishDir "${params.outdir}/", pattern: "samples_failing_read_filter.txt", mode: "copy"
 
     input:
     path(fastq)
 
     output:
-    file('READ_LENGTH_FILTERED_OUT.txt')
+    file('samples_failing_read_filter.txt')
 
     script:
     """
-    ls *.fastq > READ_LENGTH_FILTERED_OUT.txt
+    ls *.fastq > samples_failing_read_filter.txt
     """
 }
 

--- a/workflows/articNcovNanopore.nf
+++ b/workflows/articNcovNanopore.nf
@@ -18,7 +18,7 @@ include {bamToCram} from '../modules/out.nf'
 include {collateSamples} from '../modules/upload.nf'
 
 include {renameSamples} from '../modules/nml.nf'
-include {zeroReadsFiltered} from '../modules/nml.nf'
+include {accountReadFilterFailures} from '../modules/nml.nf'
 include {runNcovTools} from '../modules/nml.nf'
 include {generateFastqIridaReport} from '../modules/nml.nf'
 include {generateFastaIridaReport} from '../modules/nml.nf'
@@ -47,7 +47,7 @@ workflow sequenceAnalysisNanopolish {
        renameSamples(articGuppyPlex.out.fastq
                                        .combine(ch_irida))
 
-       zeroReadsFiltered(renameSamples.out.filter{ it.size()==0 }.collect())
+       accountReadFilterFailures(renameSamples.out.filter{ it.size()==0 }.collect())
 
        articMinIONNanopolish(renameSamples.out.filter{ it.size()>0 }
                                           .combine(articDownloadScheme.out.scheme)
@@ -63,7 +63,7 @@ workflow sequenceAnalysisNanopolish {
        Channel.fromPath("${params.irida}")
               .set{ ch_irida }
 
-       zeroReadsFiltered(articGuppyPlex.out.fastq.filter{ it.size()==0 }.collect())
+       accountReadFilterFailures(articGuppyPlex.out.fastq.filter{ it.size()==0 }.collect())
 
        articMinIONNanopolish(articGuppyPlex.out.fastq.filter{ it.size()>0 }
                                           .combine(articDownloadScheme.out.scheme)

--- a/workflows/articNcovNanopore.nf
+++ b/workflows/articNcovNanopore.nf
@@ -18,6 +18,7 @@ include {bamToCram} from '../modules/out.nf'
 include {collateSamples} from '../modules/upload.nf'
 
 include {renameSamples} from '../modules/nml.nf'
+include {zeroReadsFiltered} from '../modules/nml.nf'
 include {runNcovTools} from '../modules/nml.nf'
 include {generateFastqIridaReport} from '../modules/nml.nf'
 include {generateFastaIridaReport} from '../modules/nml.nf'
@@ -46,6 +47,8 @@ workflow sequenceAnalysisNanopolish {
        renameSamples(articGuppyPlex.out.fastq
                                        .combine(ch_irida))
 
+       zeroReadsFiltered(renameSamples.out.filter{ it.size()==0 }.collect())
+
        articMinIONNanopolish(renameSamples.out.filter{ it.size()>0 }
                                           .combine(articDownloadScheme.out.scheme)
                                           .combine(ch_fast5Pass)
@@ -59,6 +62,8 @@ workflow sequenceAnalysisNanopolish {
       else {
        Channel.fromPath("${params.irida}")
               .set{ ch_irida }
+
+       zeroReadsFiltered(articGuppyPlex.out.fastq.filter{ it.size()==0 }.collect())
 
        articMinIONNanopolish(articGuppyPlex.out.fastq.filter{ it.size()>0 }
                                           .combine(articDownloadScheme.out.scheme)


### PR DESCRIPTION
Keep track of samples that don't have enough reads or are filtered out based on read size and output them.

Read number filter can be changed in nanopore.conf

Output file names can change if needed, although I am not sure how we will push these to Irida based on how the qc csv table is generated