### PR TITLE
Change to base scheme location

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -12,7 +12,7 @@ params{
     profile = false
 
     // Repo to download your primer scheme from
-    schemeRepoURL = 'https://github.com/phac-nml/resende-ncov2019.git'
+    schemeRepoURL = 'https://github.com/phac-nml/ncov-schemes.git'
 
     // Directory within schemeRepoURL that contains primer schemes
     schemeDir = 'primer_schemes'

--- a/modules/artic.nf
+++ b/modules/artic.nf
@@ -10,7 +10,7 @@ process articDownloadScheme{
     output:
     path "scheme/**/${params.schemeVersion}/*.reference.fasta" , emit: reffasta
     path "scheme/**/${params.schemeVersion}/${params.scheme}.bed" , emit: bed
-    path "scheme/**/${params.schemeVersion}/ncov-qc_resende.bed" , emit: ncov_amplicon
+    path "scheme/**/${params.schemeVersion}/ncov-qc_*.scheme.bed" , emit: ncov_amplicon
     path "scheme" , emit: scheme
 
     script:


### PR DESCRIPTION
Change base scheme location to https://github.com/phac-nml/ncov-schemes to allow additional schemes to be more easily used, added, and modified as seen fit