### PR TITLE
Fix missed hardcoded amplicon name

### DIFF
--- a/extra_data/config.yaml
+++ b/extra_data/config.yaml
@@ -5,7 +5,7 @@ data_root: run
 run_name: nml
 
 # path to the file containing the amplicon regions (not the primer sites, the actual amplicons)
-amplicon_bed: ncov-qc_resende.bed
+amplicon_bed: input_amplicon.bed
 
 # path to the nCov reference genome
 reference_genome: nCoV-2019.reference.fasta

--- a/modules/nml.nf
+++ b/modules/nml.nf
@@ -143,7 +143,8 @@ process runNcovTools {
             sed -i -e 's/^negative_control_samples/#negative_control_samples/' ${config}
         fi
 
-        mv ${config} ${reference} ${amplicon} ./ncov-tools
+        mv ${amplicon} ./ncov-tools/input_amplicon.bed
+        mv ${config} ${reference} ./ncov-tools
         mv ${metadata} ./ncov-tools/metadata.tsv
         mkdir ./ncov-tools/run
         mv *.* ./ncov-tools/run
@@ -162,7 +163,8 @@ process runNcovTools {
         sed -i -e 's/^metadata/#metadata/' ${config}
         sed -i -e 's/^negative_control_samples/#negative_control_samples/' ${config}
         sed -i 's|/ARTIC/nanopolish||' *.consensus.fasta
-        mv ${config} ${reference} ${amplicon} ./ncov-tools
+        mv ${amplicon} ./ncov-tools/input_amplicon.bed
+        mv ${config} ${reference} ./ncov-tools
         mkdir ./ncov-tools/run
         mv *.* ./ncov-tools/run
         cd ncov-tools


### PR DESCRIPTION
Had the ncov-tools config amplicon name hard set. Now move the amplicon and rename it to allow many inputs