### PR TITLE
Change ncov-tools commands to reflect ncov-tools changes

### DIFF
--- a/bin/run_ncovtools.sh
+++ b/bin/run_ncovtools.sh
@@ -35,9 +35,9 @@ mv *.* ./ncov-tools/run
 # Go in, run the commands and generate the indexed reference sequence
 cd ncov-tools
 samtools faidx ${reference}
-snakemake -s qc/Snakefile all_qc_sequencing --cores 8
-snakemake -s qc/Snakefile all_qc_analysis --cores 8
-snakemake -s qc/Snakefile all_qc_reports --cores 4
+snakemake -s workflow/Snakefile all_qc_sequencing --cores 8
+snakemake -s workflow/Snakefile all_qc_analysis --cores 8
+snakemake -s workflow/Snakefile all_qc_reports --cores 4
 
 # Move files out so that they can be easily detected by nextflow
 mv ./plots/*.pdf ../

--- a/extra_data/config.yaml
+++ b/extra_data/config.yaml
@@ -62,4 +62,4 @@ negative_control_samples: [ "PLACEHOLDER-negative_ctrl", "PLACEHOLDER-negative_c
 
 # minimum completeness threshold for inclusion to the SNP tree plot, if no entry
 # is provided the default is set to 0.75
-completeness_threshold: 0.9
+completeness_threshold: 0.75

--- a/modules/nml.nf
+++ b/modules/nml.nf
@@ -201,9 +201,9 @@ process runNcovTools {
         mv *.* ./ncov-tools/run
         cd ncov-tools
         samtools faidx ${reference}
-        snakemake -s qc/Snakefile all_qc_sequencing --cores 8
-        snakemake -s qc/Snakefile all_qc_analysis --cores 8
-        snakemake -s qc/Snakefile all_qc_reports --cores 4
+        snakemake -s workflow/Snakefile all_qc_sequencing --cores 8
+        snakemake -s workflow/Snakefile all_qc_analysis --cores 8
+        snakemake -s workflow/Snakefile all_qc_reports --cores 4
         mv ./plots/*.pdf ../
         mv ./qc_reports/*.tsv ../
         cd ..


### PR DESCRIPTION
Location of snakefile changed from `qc/` to `workflow/` so this update reflects that

Also changed completeness threshold back down to 0.75 for some of the poorer runs so that we don't fail on Augur with only one sequence (as likely to anyway) 