### PR TITLE
addition to logging in N corrections, fix to ncov-tools failing early…

### DIFF
--- a/bin/correct_n.py
+++ b/bin/correct_n.py
@@ -368,6 +368,7 @@ If you do, please double check the BAM file in a viewer such as IGV to make sure
 
     # Find N's based on either the consensus sequence or the failed variants
     if not args.fail_vcf:
+        logging.info('Checking full sequence for Ns to correct')
         n_locations, tracking_dict = find_all_n(con_seq, del_dict)
 
         if len(n_locations) > args.max:
@@ -376,8 +377,14 @@ If you do, please double check the BAM file in a viewer such as IGV to make sure
         logging.info('N locations include {}'.format(n_locations))
 
     else:
+        logging.info('Checking {} for Ns to correct'.format(args.fail_vcf))
         n_locations, tracking_dict = find_fail_locations(args.fail_vcf, del_dict)
         logging.info('N locations include {}'.format(n_locations))
+
+        # Exit if no N's found to be corrected
+        if n_locations == []:
+            logging.info('No Ns to correct, Exitting')
+            quit()
 
     # Generate command for bcftools mpileup targeting those sites
     cmd_input = ','.join(generate_location_input(n_locations, ref_name))

--- a/bin/run_ncovtools.sh
+++ b/bin/run_ncovtools.sh
@@ -57,9 +57,9 @@ mv *.* ./ncov-tools/run
 # Go in, run the commands and generate the indexed reference sequence
 cd ncov-tools
 samtools faidx ${reference}
-snakemake -s workflow/Snakefile all --cores 8
-snakemake -s workflow/Snakefile --cores 1 build_snpeff_db
-snakemake -s workflow/Snakefile --cores 2 all_qc_annotation
+snakemake -kp -s workflow/Snakefile all --cores 8
+snakemake -kp -s workflow/Snakefile --cores 1 build_snpeff_db
+snakemake -kp -s workflow/Snakefile --cores 2 all_qc_annotation
 
 # Move files out so that they can be easily detected by nextflow
 mv ./plots/*.pdf ../

--- a/workflows/articNcovNanopore.nf
+++ b/workflows/articNcovNanopore.nf
@@ -88,6 +88,9 @@ workflow sequenceAnalysisNanopolish {
                           .join(articMinIONNanopolish.out.fail_vcf, by:0),
                           articDownloadScheme.out.reffasta)
 
+        correctFailNs.out.corrected_consensus.collect()
+              .ifEmpty(file('placeholder.txt'))
+              .set{ ch_corrected }
       }
 
       Channel.fromPath("${params.ncov}")
@@ -99,7 +102,7 @@ workflow sequenceAnalysisNanopolish {
                       articMinIONNanopolish.out[0].collect(),
                       articDownloadScheme.out.bed,
                       ch_irida,
-                      correctFailNs.out.corrected_consensus.collect())
+                      ch_corrected)
       
       snpDists(runNcovTools.out.aligned)
 


### PR DESCRIPTION
Looking through Log files I realized that the N correction should report differently for the vcf input if no Ns are found to correct. That has been adjusted by just adding an INFO statement that we exited as there was nothing found

Related issue to this was that ncov-tools was not starting if all files passed the correction step, leading to failures and no qc output. Addressed by adding a check for if the channel is empty and creating a dummy file if so to get it to run
- May be a better solution to this but this works for the moment
 
With this ncov-tools issue, another new one popped up where metadata that previously worked was causing issues. Explicitly with the `make_qc_plot_amplicon_depth_by_ct` plot when all of the ct's were NA (never saw this previously but that is ok). This has been addressed by adding `-kp` to the snakemake commands to allow it to skip past the errors and let nextflow determine if we've failed what we need for the output

Tested on all previously failing datasets and got final outputs for all of them