### PR TITLE
Update artic to v1.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ A few changes and additions have been made to optimize running this pipeline for
 
 The specifics are found in the nml config and the process is built off of a slurm executor with conda environments for different processes.
 
+**Note from updating artic fieldinformatics to v1.2.1:** [Field informatics](https://github.com/artic-network/fieldbioinformatics) update fixed a rare issue causing samples to fail even when they were of high quality. It also added new checking for primer schemes that had to be modified in the conda environment to allow the internal primer schemes to be used.
+
 **Running**
 
 1. Set up [ncov-tools](https://github.com/jts/ncov-tools/blob/master/workflow/envs/environment.yml) environment

--- a/environments/nanopore/environment.yml
+++ b/environments/nanopore/environment.yml
@@ -4,4 +4,5 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - artic
+  - artic=1.2.1
+  - pyyaml=5.3.1

--- a/modules/artic.nf
+++ b/modules/artic.nf
@@ -135,7 +135,8 @@ process articMinIONNanopolish {
     --read-file ${fastq} \
     --fast5-directory ${fast5Pass} \
     --sequencing-summary ${seqSummary} \
-    ${params.scheme}/${params.schemeVersion} \
+    --scheme-version ${params.schemeVersion} \
+    ${params.scheme} \
     ${sampleName}
     """
 }


### PR DESCRIPTION
Were updating the artic fieldinformatics module and environment to the latest version to get all of the new changes and fixes.

This version does not seem to like the way that our schemes are named and as such, the environment generated has to have the specific lines modified for it to work correctly at the moment