### PR TITLE
Add flat fastq workflow for medaka

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -35,6 +35,9 @@ params{
     // Run nanopolish pipeline
     nanopolish = false
 
+    // Run a flat nanopore directory with medaka (also need the --medaka flag)
+    flat = false
+
     // Run Irida Upload
     irida = false
 

--- a/main.nf
+++ b/main.nf
@@ -90,7 +90,7 @@ workflow {
    else {
        // Check to see if we have barcodes
        nanoporeBarcodeDirs = file("${params.basecalled_fastq}/barcode*", type: 'dir', maxdepth: 1 )
-       nanoporeNoBarcode = file("${params.basecalled_fastq}/*.fastq", type: 'file', maxdepth: 1)
+       nanoporeNoBarcode = file("${params.basecalled_fastq}/*.fastq*", type: 'file', maxdepth: 1)
 
        if( nanoporeBarcodeDirs ) {
             // Yes, barcodes!

--- a/modules/artic.nf
+++ b/modules/artic.nf
@@ -42,6 +42,36 @@ process articGuppyPlex {
     """
 }
 
+process articGuppyPlexFlat {
+    tag { params.prefix + "-" + fastq }
+
+    label 'largemem'
+
+    publishDir "${params.outdir}/${task.process.replaceAll(":","_")}", pattern: "*.fastq", mode: "copy"
+
+    input:
+    path(fastq)
+
+    output:
+    path "*.fastq", emit: fastq
+
+    // Utilize the sampleName to not have to rename anything later on
+    //  Have to do the final mv command we need a different name from input (why we have the _prefix)
+    script:
+    sampleName = fastq.getBaseName().replaceAll(~/\.fastq.*$/, '')
+    """
+    mkdir -p input_fastq
+    mv $fastq input_fastq
+    artic guppyplex \
+    --min-length ${params.min_length} \
+    --max-length ${params.max_length} \
+    --prefix ${params.prefix} \
+    --directory input_fastq
+
+    mv ${params.prefix}_input_fastq.fastq ${sampleName}_${params.prefix}.fastq
+    """
+}
+
 process articMinIONMedaka {
     tag { sampleName }
 

--- a/modules/artic.nf
+++ b/modules/artic.nf
@@ -47,20 +47,21 @@ process articGuppyPlexFlat {
 
     label 'largemem'
 
-    publishDir "${params.outdir}/${task.process.replaceAll(":","_")}", pattern: "*.fastq", mode: "copy"
+    publishDir "${params.outdir}/${task.process.replaceAll(":","_")}", pattern: "out/${sampleName}.fastq", mode: "copy"
 
     input:
     path(fastq)
 
     output:
-    path "*.fastq", emit: fastq
+    path "out/${sampleName}.fastq", emit: fastq
 
-    // Utilize the sampleName to not have to rename anything later on
-    //  Have to do the final mv command we need a different name from input (why we have the _prefix)
+    // Utilize the sampleName to keep the name consistent
+    //  Have to use out dir for the end name as otherwise the file is the same as the input
     script:
     sampleName = fastq.getBaseName().replaceAll(~/\.fastq.*$/, '')
     """
     mkdir -p input_fastq
+    mkdir -p out
     mv $fastq input_fastq
     artic guppyplex \
     --min-length ${params.min_length} \
@@ -68,7 +69,7 @@ process articGuppyPlexFlat {
     --prefix ${params.prefix} \
     --directory input_fastq
 
-    mv ${params.prefix}_input_fastq.fastq ${sampleName}_${params.prefix}.fastq
+    mv ${params.prefix}_input_fastq.fastq out/${sampleName}.fastq
     """
 }
 

--- a/modules/help.nf
+++ b/modules/help.nf
@@ -44,6 +44,7 @@ def printHelp() {
       --minReadsPerBarcode    Minimum number of reads accepted for a single barcode when supplying deplexed Fastq
                               files as input. Barcodes having fewer reads are ignored. (Default: 100)
                               
+      --flat                  Run fastq files from a flat folder through the medaka pipeline (Still MUST pass --medaka)
       --ncov                  Path to ncov-tools config file (Default: baseDir/extra_data/config.yaml)
       --irida                 Path to Irida sample_list.tsv file to rename data and upload to Irida (Default: false)
                               Sample_list.tsv should be formated as [sample, run, barcode, project_id, ct]


### PR DESCRIPTION
## Purpose
With external data, we need a flat workflow for nanopore data. The current implementation does not support this so a separate workflow was established

## Changes
- Added `--flat` parameter to access the workflow (must be passed with `--medaka`)
- New "sequenceAnalysisMedakaFlat" workflow