### PR TITLE
Move amplicon table to be detected

### DIFF
--- a/bin/run_ncovtools.sh
+++ b/bin/run_ncovtools.sh
@@ -66,6 +66,7 @@ snakemake -kp -s workflow/Snakefile all --cores ${CORES}
 mv ./plots/*.pdf ../
 mv ./qc_reports/*.tsv ../
 mv ./qc_analysis/nml_aligned.fasta ../
+mv ./qc_analysis/nml_amplicon_coverage_table.tsv ../
 cd ..
 
 # Touching a negative control so that there always is one (even if we remove the check)


### PR DESCRIPTION
## Changes
- Added move command to ncov-tools bash script to get the amplicon coverage table