### PR TITLE
Modify Medaka Resources 

### DIFF
--- a/conf/coguk/nml.config
+++ b/conf/coguk/nml.config
@@ -12,7 +12,13 @@ process {
         clusterOptions = "--partition=OutbreakResponse -c 16 --mem=64G"
         cpus = 16
         memory = 64.GB
-    } 
+    }
+
+    withLabel: mediumcpu {
+        clusterOptions = "--partition=OutbreakResponse -c 4 --mem=32G"
+        cpus = 4
+        memory = 32.GB
+    }
 
     withLabel: smallmem {
         clusterOptions = "--partition=OutbreakResponse -c 2 --mem=4G"

--- a/conf/coguk/nml.config
+++ b/conf/coguk/nml.config
@@ -2,7 +2,7 @@ process {
 
     // Base process
     executor = "slurm"
-    clusterOptions = "--partition=OutbreakResponse -c 16 --mem=64G"
+    clusterOptions = "--partition=OutbreakResponse -c 2 --mem=16G"
 
     // Allow up to 4 retries per process
     errorStrategy = 'retry'

--- a/conf/resources.config
+++ b/conf/resources.config
@@ -4,7 +4,7 @@ process {
     withLabel: largecpu {
         cpus = 4
     }
-    withLabel: ncovtools {
-        cpus = 4
+    withLabel: mediumcpu {
+        cpus = 3
     }
 }

--- a/modules/artic.nf
+++ b/modules/artic.nf
@@ -90,7 +90,7 @@ process articGuppyPlexFlat {
 process articMinIONMedaka {
     tag { sampleName }
 
-    label 'largecpu'
+    label 'mediumcpu'
 
     publishDir "${params.outdir}/${task.process.replaceAll(":","_")}", pattern: "${sampleName}*", mode: "copy"
 

--- a/modules/nml.nf
+++ b/modules/nml.nf
@@ -169,7 +169,7 @@ process runNcovTools {
     //conda 'environments/ncovtools.yml'
     // Make conda env with mamba or it will error (takes 3+ hours without)
 
-    label 'ncovtools'
+    label 'mediumcpu'
 
     input:
     file(config)


### PR DESCRIPTION
## Changes
- ncovtools label removed
  - mediumcpu label added instead
- ncovtools and medaka processes changed to mediumcpu

## Reason
- Labels changed as it seemed medaka was having issues with the high amount of resources given to it