### PR TITLE
Track failed samples in final qc.csv output

### DIFF
--- a/conf/coguk/nml.config
+++ b/conf/coguk/nml.config
@@ -1,3 +1,7 @@
+env {
+    OPENBLAS_NUM_THREADS = 32
+}
+
 process {
 
     // Base process

--- a/modules/artic.nf
+++ b/modules/artic.nf
@@ -133,6 +133,7 @@ process articMinIONMedaka {
     --threads ${task.cpus} \
     --scheme-directory ${schemeRepo} \
     --read-file ${fastq} \
+    --no-longshot \
     --medaka-model ${params.medakaModel} \
     --scheme-version ${params.schemeVersion} \
     ${params.scheme} \

--- a/modules/artic.nf
+++ b/modules/artic.nf
@@ -133,7 +133,6 @@ process articMinIONMedaka {
     --threads ${task.cpus} \
     --scheme-directory ${schemeRepo} \
     --read-file ${fastq} \
-    --no-longshot \
     --medaka-model ${params.medakaModel} \
     --scheme-version ${params.schemeVersion} \
     ${params.scheme} \

--- a/modules/artic.nf
+++ b/modules/artic.nf
@@ -8,7 +8,7 @@ process articDownloadScheme{
     publishDir "${params.outdir}/${task.process.replaceAll(":","_")}", pattern: "${params.schemeDir}", mode: "copy"
 
     output:
-    path "${params.schemeDir}/${params.scheme}/${params.schemeVersion}/*.reference.fasta" , emit: reffasta
+    path "${params.schemeDir}/${params.scheme}/${params.schemeVersion}/${params.scheme}.reference.fasta" , emit: reffasta
     path "${params.schemeDir}/${params.scheme}/${params.schemeVersion}/${params.scheme}.bed" , emit: bed
     path "${params.schemeDir}/${params.scheme}/${params.schemeVersion}/ncov-qc_*.scheme.bed" , emit: ncov_amplicon
     path "${params.schemeDir}" , emit: scheme

--- a/modules/artic.nf
+++ b/modules/artic.nf
@@ -22,7 +22,7 @@ process articDownloadScheme{
 process articGuppyPlex {
     tag { params.prefix + "-" + fastqDir }
 
-    label 'largemem'
+    label 'mediumcpu'
 
     publishDir "${params.outdir}/${task.process.replaceAll(":","_")}", pattern: "${params.prefix}*.fastq", mode: "copy"
 
@@ -52,7 +52,7 @@ process articGuppyPlex {
 process articGuppyPlexFlat {
     tag { params.prefix + "-" + fastq }
 
-    label 'largemem'
+    label 'mediumcpu'
 
     publishDir "${params.outdir}/${task.process.replaceAll(":","_")}", pattern: "out/${sampleName}.fastq", mode: "copy"
 

--- a/modules/nml.nf
+++ b/modules/nml.nf
@@ -72,14 +72,14 @@ process accountReadFilterFailures {
 
     label 'smallmem'
 
-    publishDir "${params.outdir}/", pattern: "samples_failing_read_filter.tsv", mode: "copy"
+    publishDir "${params.outdir}/", pattern: "samples_failing_read_size_filter.tsv", mode: "copy"
 
     input:
     path(fastq)
     file(sampletsv)
 
     output:
-    path 'samples_failing_read_filter.tsv', optional: true, emit: map_filter
+    path 'samples_failing_read_size_filter.tsv', optional: true, emit: size_filter
 
     shell:
     '''
@@ -94,7 +94,7 @@ process accountReadFilterFailures {
 
         ## Set header
         header=$(head -n 1 !{sampletsv})
-        echo "$header	qc_pass" > samples_failing_read_filter.tsv
+        echo "$header	qc_pass" > samples_failing_read_size_filter.tsv
 
         for fastq in *.fastq; do
             ## Removes all extensions to get the sample name, "." are not allowed in IRIDA sample names anyway
@@ -103,16 +103,16 @@ process accountReadFilterFailures {
             fileline=$(awk -F'\t' -v col="$sample_col" -v filename="$filename"  '$col == filename' !{sampletsv})
             ## No matches, skip line
             if [ "$fileline" != "" ]; then
-                echo "$fileline	TOO_FEW_MAPPING_READS" >> samples_failing_read_filter.tsv
+                echo "$fileline	TOO_FEW_SIZE_SELECTED_READS" >> samples_failing_read_size_filter.tsv
             fi
         done
     ## No samplesheet, just track that the barcode failed
     else
-        echo "sample	qc_pass" > samples_failing_read_filter.tsv
+        echo "sample	qc_pass" > samples_failing_read_size_filter.tsv
         for fastq in *.fastq; do
             ## Removes all extensions to get the sample name, "." are not allowed in IRIDA sample names anyway
             filename="${fastq%%.*}"
-            echo "$filename	TOO_FEW_MAPPING_READS" >> samples_failing_read_filter.tsv
+            echo "$filename	TOO_FEW_SIZE_SELECTED_READS" >> samples_failing_read_size_filter.tsv
         done
     fi
     '''

--- a/modules/qc.nf
+++ b/modules/qc.nf
@@ -57,7 +57,7 @@ process makeQCCSV {
         --vcf ${vcf} \
         --revision ${rev} \
         --scheme ${params.schemeVersion} \
-        --scheme_bed ${} \
+        --scheme_bed ${scheme_bed} \
         --sequencing_technology ${params.sequencingTechnology} \
         --snpeff_tsv ${snp_eff_path}/${sampleName}_aa_table.tsv \
         --pcr_bed ${pcr_bed}
@@ -91,12 +91,26 @@ process correctQCSummaryCSV {
 
     input:
     file(initial_qc_csv)
+    file(read_count_failures)
+    file(read_filter_failures)
 
     output:
     file("${params.prefix}.qc.csv")
 
     script:
     """
+    if [ -f ${read_count_failures} ]; then 
+        READ_FILTER="${read_count_failures}"
+    else
+        READ_FILTER=""
+    fi
+    
+    if [ -f ${read_filter_failures} ]; then
+        MAPPING_FILTER="${read_filter_failures}"
+    else
+        MAPPING_FILTER=""
+    fi
+    
     negative_control_fixes.py --qc_csv ${initial_qc_csv} --output_prefix ${params.prefix}
     """
 }

--- a/modules/qc.nf
+++ b/modules/qc.nf
@@ -100,17 +100,17 @@ process correctQCSummaryCSV {
     script:
     """
     if [ -f ${read_count_failures} ]; then 
-        READ_FILTER="${read_count_failures}"
+        READ_FILTER="--read_tsv ${read_count_failures}"
     else
         READ_FILTER=""
     fi
-    
+
     if [ -f ${read_filter_failures} ]; then
-        MAPPING_FILTER="${read_filter_failures}"
+        MAPPING_FILTER="--mapping_tsv ${read_filter_failures}"
     else
         MAPPING_FILTER=""
     fi
-    
-    negative_control_fixes.py --qc_csv ${initial_qc_csv} --output_prefix ${params.prefix}
+
+    negative_control_fixes.py --qc_csv ${initial_qc_csv} --output_prefix ${params.prefix} \${READ_FILTER} \${MAPPING_FILTER}
     """
 }

--- a/workflows/articNcovNanopore.nf
+++ b/workflows/articNcovNanopore.nf
@@ -70,7 +70,7 @@ workflow sequenceAnalysisNanopolish {
 
        accountReadFilterFailures(renameSamples.out.filter{ it.countFastq() <= params.minReadsArticGuppyPlex }.collect(),
                                   ch_irida)
-       accountReadFilterFailures.out.map_filter
+       accountReadFilterFailures.out.size_filter
         .ifEmpty(file('placeholder_accountReadFilterFailures.txt'))
         .set{ ch_filterReadsTracking }
 
@@ -91,7 +91,7 @@ workflow sequenceAnalysisNanopolish {
 
        accountReadFilterFailures(articGuppyPlex.out.fastq.filter{ it.countFastq() <= params.minReadsArticGuppyPlex }.collect(),
                                   ch_irida)
-       accountReadFilterFailures.out.map_filter
+       accountReadFilterFailures.out.size_filter
         .ifEmpty(file('placeholder_accountReadFilterFailures.txt'))
         .set{ ch_filterReadsTracking }
 
@@ -225,7 +225,7 @@ workflow sequenceAnalysisMedaka {
 
        accountReadFilterFailures(renameSamples.out.filter{ it.countFastq() <= params.minReadsArticGuppyPlex }.collect(),
                                   ch_irida)
-       accountReadFilterFailures.out.map_filter
+       accountReadFilterFailures.out.size_filter
         .ifEmpty(file('placeholder_accountReadFilterFailures.txt'))
         .set{ ch_filterReadsTracking }
 
@@ -243,7 +243,7 @@ workflow sequenceAnalysisMedaka {
 
        accountReadFilterFailures(articGuppyPlex.out.fastq.filter{ it.countFastq() <= params.minReadsArticGuppyPlex }.collect(),
                                   ch_irida)
-       accountReadFilterFailures.out.map_filter
+       accountReadFilterFailures.out.size_filter
         .ifEmpty(file('placeholder_accountReadFilterFailures.txt'))
         .set{ ch_filterReadsTracking }
 
@@ -365,7 +365,7 @@ workflow sequenceAnalysisMedakaFlat {
 
       accountReadFilterFailures(articGuppyPlexFlat.out.fastq.filter{ it.countFastq() <= params.minReadsArticGuppyPlex }.collect(),
                                   ch_irida)
-      accountReadFilterFailures.out.map_filter
+      accountReadFilterFailures.out.size_filter
         .ifEmpty(file('placeholder_accountReadFilterFailures.txt'))
         .set{ ch_filterReadsTracking }
 

--- a/workflows/articNcovNanopore.nf
+++ b/workflows/articNcovNanopore.nf
@@ -81,7 +81,10 @@ workflow sequenceAnalysisNanopolish {
                                           .combine(ch_seqSummary))
        ch_versions = ch_versions.mix(articMinIONNanopolish.out.versions.first())
 
-       generateFastqIridaReport(renameSamples.out.collect(),
+       // Adding size filter for IRIDA uploads, 1kB needed
+       generateFastqIridaReport(renameSamples.out
+                                             .filter{ it.size() > 1024 }
+                                             .collect(),
                                 ch_irida)
 
        generateFastaIridaReport(articMinIONNanopolish.out.consensus_fasta.collect(),
@@ -233,8 +236,11 @@ workflow sequenceAnalysisMedaka {
                                       .filter{ it.countFastq() > params.minReadsArticGuppyPlex }
                                       .combine(articDownloadScheme.out.scheme))
        ch_versions = ch_versions.mix(articMinIONMedaka.out.versions.first())
-
-       generateFastqIridaReport(renameSamples.out.collect(),
+        
+       // Adding size filter for IRIDA uploads, 1kB needed
+       generateFastqIridaReport(renameSamples.out
+                                             .filter{ it.size() > 1024 }
+                                             .collect(),
                                 ch_irida)
 
        generateFastaIridaReport(articMinIONMedaka.out.consensus_fasta.collect(),
@@ -442,9 +448,9 @@ workflow sequenceAnalysisMedakaFlat {
        if (params.upload_irida) {
          Channel.fromPath("${params.upload_irida}")
              .set{ ch_upload }
-        
+
          // Generate upload datasets
-         generateFastqIridaReport(articGuppyPlexFlat.out.fastq.collect(), ch_irida)
+         generateFastqIridaReport(articGuppyPlexFlat.out.fastq.filter{ it.size() > 1024 }.collect(), ch_irida)
          generateFastaIridaReport(articMinIONMedaka.out.consensus_fasta.collect(), ch_irida)
 
          // Upload


### PR DESCRIPTION
## Changes:
- samples that fail the read coun and size selection filters will now be found in the nml.qc.csv file
    - The previous tracking txt files are now tsv files with the data in them and if a samplesheet is given, the file contains the samplesheet info
        - samples_failing_no_input_reads.tsv
        - samples_failing_read_size_filter.tsv
- Adds environment variable for OpenBLAS threads to fix issues with the nml config spawning too many

## Under the hood adjustments:
- articNcovNanopore workflow now takes both the `fastq dirs` and the `bad fastq dirs` as input
- Setting the samplesheet channel is now done in the articNcovNanopore workflow instead of the sub workflows
- failing read count now specifically in the pipeline instead of in main