### PR TITLE
Small conda environment updates

### DIFF
--- a/environments/ncovtools.yml
+++ b/environments/ncovtools.yml
@@ -29,12 +29,10 @@ dependencies:
   - usher
   - pip:
       - dendropy>=4.4.0
-      - pyvcf
+      - pyvcf3
       - ncov-parser
-      - git+https://github.com/hCoV-2019/lineages.git
-      - git+https://github.com/hCoV-2019/pangolin.git
-      - git+https://github.com/cov-lineages/pangoLEARN.git
+      - git+https://github.com/cov-lineages/pangolin.git
+      - git+https://github.com/cov-lineages/pangolin-data.git
       - git+https://github.com/cov-lineages/constellations.git
       - git+https://github.com/cov-lineages/scorpio.git
-      - git+https://github.com/cov-lineages/pango-designation.git
       - git+https://github.com/jts/ncov-watch.git

--- a/nextflow.config
+++ b/nextflow.config
@@ -29,6 +29,9 @@ conda.cacheDir = '/Drives/P/conda_envs/connor-lab'
 profiles {
   conda {
      conda.createTimeout = '3 h'
+
+     // Use Mamba as its a lot faster
+     conda.useMamba = true
      
      if ( params.medaka || params.nanopolish ) {
        process.conda = "$baseDir/environments/nanopore/environment.yml"


### PR DESCRIPTION
## Changes
- Fixed ncov-tools env to work with pangolin 4
    - Was previously just updated manually to work for pangolin 4, now the env in this repo matches that in ncov-tools
- Add the `conda.useMamba` option for conda env creation