### PR TITLE
Force string column type for sample in IRIDA CSV Gen

### DIFF
--- a/bin/irida_fast5.py
+++ b/bin/irida_fast5.py
@@ -93,8 +93,7 @@ def create_sample_archive_df(sample_tsv, directory, output_dir, row_list=[]):
 
 
 def main():
-    
-     # Init Parser and set arguments
+    # Init Parser and set arguments
     parser = init_parser()
     args = parser.parse_args()
 

--- a/bin/irida_upload_csv_generator.py
+++ b/bin/irida_upload_csv_generator.py
@@ -35,7 +35,8 @@ def create_sample_file_df(sample_tsv, sample_dir, file_type='', file_list=[]):
     '''
     # Read in input TSV file
     df = pd.read_csv(sample_tsv, sep='\t')
-    
+    df['sample'] = df['sample'].astype("string")
+
     # Get all of the fasta files in the input folder to a list to check against our sample_tsv df
     if file_type == 'fastq':
         FILE_WANTED_REGEX = re.compile(r'^.+\.fastq$')


### PR DESCRIPTION
Issue with samplesheets that just had integer IDs not running through the CSV generation step.

Forcing the sample column to be a string looks to fix it