### PR TITLE
Change ncov-tools to pangolin accurate

### DIFF
--- a/extra_data/config.yaml
+++ b/extra_data/config.yaml
@@ -53,7 +53,7 @@ assign_lineages: true
 # set analysis mode for pangolin. Either 'fast' or 'accurate'
 #  default is accurate
 #
-pango_analysis_mode: "fast"
+pango_analysis_mode: "accurate"
 
 #
 # this flag should identify the sequencing platform used, valid options are:


### PR DESCRIPTION
Changing ncov-tools to run pangolin in accurate (usher) mode to try to assign more lineages