### PR TITLE
Update logic for artic medaka pipeline

### DIFF
--- a/.github/scripts/test_nml_nanopore_medaka.sh
+++ b/.github/scripts/test_nml_nanopore_medaka.sh
@@ -6,7 +6,7 @@ mkdir -p conda_cache_dir
 
 ### Run Medaka Pipeline ###
 nextflow run ./main.nf \
-    -profile conda,test \
+    -profile mamba,test \
     --cache ./conda_cache_dir \
     --medaka \
     --prefix 'nml' \

--- a/.github/scripts/test_nml_nanopore_medaka_flat.sh
+++ b/.github/scripts/test_nml_nanopore_medaka_flat.sh
@@ -6,7 +6,7 @@ mkdir -p conda_cache_dir
 
 ### Run Medaka Pipeline Flat ###
 nextflow run ./main.nf \
-    -profile conda,test \
+    -profile mamba,test \
     --cache ./conda_cache_dir \
     --medaka \
     --flat \

--- a/.github/scripts/test_nml_nanopore_nanopolish.sh
+++ b/.github/scripts/test_nml_nanopore_nanopolish.sh
@@ -15,7 +15,7 @@ fi
 
 ### Run Nanopolish Pipeline ###
 nextflow run ./main.nf \
-    -profile conda,test \
+    -profile mamba,test \
     --cache ./conda_cache_dir \
     --nanopolish \
     --prefix 'nml' \

--- a/conf/conda.config
+++ b/conf/conda.config
@@ -2,7 +2,6 @@
 process {
     // Conda Settings
     conda.createTimeout = '3 h'
-    conda.useMamba = true
 
     // Base Env Loading (Nanopore or Illumina)
     if ( params.medaka || params.nanopolish ) {

--- a/environments/extras.yml
+++ b/environments/extras.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   - biopython
-  - bcftools
+  - bcftools=1.15.1
   - matplotlib
   - mafft
   - pandas

--- a/modules/artic.nf
+++ b/modules/artic.nf
@@ -90,6 +90,10 @@ process articMinIONMedaka {
     label 'mediumcpu'
     publishDir "${params.outdir}/${task.process.replaceAll(":","_")}", pattern: "${sampleName}*", mode: "copy"
 
+    // Specific error strategy here due to bcftools consensus issue occuring semi-frequently
+    maxRetries 3
+    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'ignore' }
+
     input:
     tuple file(fastq), file(schemeRepo)
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -31,6 +31,14 @@ profiles {
       conda.cacheDir = params.cache
     }
   }
+  mamba {
+    conda.enabled = true
+    conda.useMamba = true
+    includeConfig 'conf/conda.config'
+    if ( params.cache ) {
+      conda.cacheDir = params.cache
+    }
+  }
   slurm {
     process.executor = 'slurm'
   }


### PR DESCRIPTION
## Reason
BCFTools in the artic medaka pipeline fails semi-frequently due to how masking is performed. This update changes the logic to attempt the artic pipeline 3 times and if it fails all 3 times, the error is ignored and the sample skipped

Along with this, internally, a process has been written to pull out these failed samples after the run is done. I am not sure if there is a way to pull out failing samples in the pipeline itself or I would do it that way

## Changes
- Ignore errors in ONLY medaka artic pipeline step
- Pin BCFTools to v1.15.1 in extras environment
- Added a mamba profile to separate mamba from conda