### PR TITLE
Fix integer only names failing qc.py

### DIFF
--- a/bin/qc.py
+++ b/bin/qc.py
@@ -330,7 +330,9 @@ def parse_ncov_tsv(file_in, sample, negative=False):
     sample_column = 'sample'
 
     # Finding the data, all samples will be in ncov-tools summary output (as they had data generated)
+    # Implemented not great, should re-visit at some point
     for index, name in enumerate(df[sample_column].tolist()):
+        name = str(name)
         if re.search(sample, name):
             df.loc[index, sample_column] = sample
             df.fillna('NA', inplace=True)


### PR DESCRIPTION
Integer only names were failing qc.py due to a regex step. Adjusted that step to just force the input as a string

At some point the qc.py script should be revisited to make some improvements to the code but for now this should fix the issue