### PR TITLE
Adjust internal retry strategy for artic MinION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v2.0.2 - [2024-07-23]
+Version 2.0.2 adjusts internal retry resources
+
 ## v2.0.1 - [2024-07-15]
 Version 2.0.1 fixes a minor bug in which all numeric sample names (ex. 231301) were not being compared to the nextclade output for frameshift reporting and adjustments along with updating the nextclade dataset to default to 'latest'
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ This Nextflow pipeline automates the ARTIC network [nCoV-2019 novel coronavirus 
 ### Release Notes
 For full changes visit the [CHANGELOG](CHANGELOG.md)
 
+#### *v2.0.2
+Version 2.0.2 adjusts internal retry resources
+
 #### *v2.0.1*
 Version 2.0.1 fixes a minor bug in which all numeric sample names (ex. 231301) were not being compared to the nextclade output for frameshift reporting and adjustments along with updating the nextclade dataset to 'latest'
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -39,5 +39,8 @@ process {
         cpus   = { check_max( 2     * task.attempt, 'cpus'    ) }
         memory = { check_max( 16.GB * task.attempt, 'memory'  ) }
         time   = { check_max( 8.h   * task.attempt, 'time'    ) }
+        // Fail if uploads have an issue so that we don't partially
+        //  upload data more than once
+        errorStrategy = 'finish'
     }
 }

--- a/conf/nml.config
+++ b/conf/nml.config
@@ -20,7 +20,7 @@ process {
 
     // Allow up to 3 retries per process
     errorStrategy = 'retry'
-    maxRetries = 2
+    maxRetries = 3
 
     // Set resources based on module label
     withLabel: largecpu {
@@ -45,6 +45,6 @@ process {
     }
     // Specific ignore to get past bcftools issue which is handled in another step
     withName: articMinION {
-        errorStrategy = { task.attempt < 2 ? 'retry' : 'ignore' } // It did not like using maxRetries here for some reason
+        errorStrategy = { task.attempt <= 3 ? 'retry' : 'ignore' }
     }
 }

--- a/conf/nml.config
+++ b/conf/nml.config
@@ -18,9 +18,9 @@ process {
     cpus        = 2
     memory      = 8.GB
 
-    // Allow up to 4 retries per process
+    // Allow up to 3 retries per process
     errorStrategy = 'retry'
-    maxRetries = 4
+    maxRetries = 2
 
     // Set resources based on module label
     withLabel: largecpu {
@@ -42,5 +42,9 @@ process {
     withLabel: fast5compress {
         cpus = 8
         memory = 32.GB
+    }
+    // Specific ignore to get past bcftools issue which is handled in another step
+    withName: articMinION {
+        errorStrategy = { task.attempt < 2 ? 'retry' : 'ignore' } // It did not like using maxRetries here for some reason
     }
 }


### PR DESCRIPTION
Revert back to internally ignoring errors when artic MinION fails due to the bcftools issue